### PR TITLE
use Restart=on-failure as recommended setting in systemd services

### DIFF
--- a/roles/validators/README.md
+++ b/roles/validators/README.md
@@ -293,22 +293,12 @@ ExecStart=/home/joystream/joystream-node \
         --pruning archive \
         --validator \
         --name <nodename>
-Restart=always
-RuntimeMaxSec=86400
+Restart=on-failure
 RestartSec=3
 LimitNOFILE=8192
 
 [Install]
 WantedBy=multi-user.target
-```
-
-If you just want to have the node restart if it crashes, replace:
-
-```
-Restart=always
-RuntimeMaxSec=86400
-# with
-Restart=on-failure
 ```
 
 
@@ -333,8 +323,7 @@ ExecStart=/root/joystream-node \
         --pruning archive \
         --validator \
         --name <nodename>
-Restart=always
-RuntimeMaxSec=86400
+Restart=on-failure
 RestartSec=3
 LimitNOFILE=8192
 
@@ -342,14 +331,6 @@ LimitNOFILE=8192
 WantedBy=multi-user.target
 ```
 
-If you just want to have the node restart if it crashes, replace:
-
-```
-Restart=always
-RuntimeMaxSec=86400
-# with
-Restart=on-failure
-```
 
 #### Starting the service
 


### PR DESCRIPTION
`on-failure` should be the recommended value for `Restart` policy in systemd service files for services we are running.

See ref: https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=

Also there is no reason to limit how long the service should run for, it is actually counter productive, so removed `RuntimeMaxSec`.

In recent event https://github.com/Joystream/substrate-runtime-joystream/issues/199 it seems multiple validators nodes were killed (without an error exit code) and had `Restart=always` which prevented their node from coming back online and we saw a drop in validators.

So Validator operators should be alerted in telegram perhaps to update their `joystream-node.service` file accordingly.